### PR TITLE
zabbix cannot use nmap

### DIFF
--- a/nethserver-zabbix.spec
+++ b/nethserver-zabbix.spec
@@ -11,6 +11,7 @@ Source: %{name}-%{version}.tar.gz
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-buildroot
 #Requires: zabbix-web-pgsql-scl
 Requires: nethserver-postgresql,zabbix-server-pgsql,zabbix-agent,zabbix-web,net-snmp-utils,nethserver-net-snmp,php-pgsql,nethserver-rh-php73-php-fpm
+Requires: nmap
 Conflicts: nethserver-zabbix22
 BuildRequires: nethserver-devtools
 BuildArch: noarch

--- a/root/etc/sudoers.d/50_nsapi_nethserver_zabbix
+++ b/root/etc/sudoers.d/50_nsapi_nethserver_zabbix
@@ -4,4 +4,6 @@
 Cmnd_Alias NSAPI_NETHSERVER_ZABBIX = \
     /usr/libexec/nethserver/api/nethserver-zabbix/read
 
+zabbix ALL=(ALL) NOPASSWD: /usr/bin/nmap -O *
+
 Defaults!NSAPI_NETHSERVER_ZABBIX !requiretty

--- a/root/etc/sudoers.d/50_nsapi_nethserver_zabbix
+++ b/root/etc/sudoers.d/50_nsapi_nethserver_zabbix
@@ -4,6 +4,6 @@
 Cmnd_Alias NSAPI_NETHSERVER_ZABBIX = \
     /usr/libexec/nethserver/api/nethserver-zabbix/read
 
-zabbix ALL=(ALL) NOPASSWD: /usr/bin/nmap -O *
+zabbix ALL= NOPASSWD: /usr/bin/nmap
 
 Defaults!NSAPI_NETHSERVER_ZABBIX !requiretty


### PR DESCRIPTION
Zabbix user cannot starts nmap because nmap is not installed, zabbix must have nmap in sudo configuration

on a host map, do a left click, detect operating system