### PR TITLE
Keep other 3th party repos enabled as much as possible

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -22,6 +22,7 @@ templates2events("/etc/zabbix/zabbix_server.conf", $event);
 templates2events("/etc/zabbix/web/zabbix.conf.php", $event);
 templates2events("/var/lib/pgsql/data/pg_hba.conf", $event);
 templates2events("/etc/opt/rh/rh-php73/php-fpm.d/zabbix.conf", $event);
+templates2events("/etc/nethserver/eorepo.conf", $event);
 
 event_services($event,
                'zabbix-server' => 'restart',

--- a/createlinks
+++ b/createlinks
@@ -12,7 +12,6 @@ use esmith::Build::CreateLinks qw(:all);
 my $event = 'nethserver-zabbix-update';
 event_actions ($event,
      'initialize-default-databases' => '00',
-     'nethserver-zabbix_enablerepo' => '10',
      'nethserver-zabbix-conf' => '10',
      'nethserver-zabbix-conf-db' => '90'
 );

--- a/root/etc/e-smith/events/actions/nethserver-zabbix_enablerepo
+++ b/root/etc/e-smith/events/actions/nethserver-zabbix_enablerepo
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo '[NOTICE] applying new YUM repository configuration'
-exec /sbin/e-smith/signal-event software-repos-save


### PR DESCRIPTION
Omit running signal-event software-repos-save explicitly

One does not need to run `signal-event software-repos-save` to install and enable the required repo.
Running `software-repos-save` often confuses people, especially on non-subscription, as it disables all repositories not listed in `/etc/nethserver/eorepo.conf`

Also see:
https://github.com/stephdl/dev/issues/18